### PR TITLE
Improvements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,10 @@ import PackageDescription
 
 let package = Package(
     name: "fx-upscale",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v13), .iOS(.v16)],
     products: [
         .executable(name: "fx-upscale", targets: ["fx-upscale"]),
+        .library(name: "Upscaling", targets: ["Upscaling"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
@@ -17,8 +18,10 @@ let package = Package(
             name: "fx-upscale",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "SwiftTUI", package: "SwiftTUI")
+                .product(name: "SwiftTUI", package: "SwiftTUI"),
+                "Upscaling"
             ]
         ),
+        .target(name: "Upscaling")
     ]
 )

--- a/Sources/Upscaling/Extensions/CMFormatDescription+Extensions.swift
+++ b/Sources/Upscaling/Extensions/CMFormatDescription+Extensions.swift
@@ -1,0 +1,62 @@
+import AVFoundation
+
+extension CMFormatDescription {
+    var videoCodecType: AVVideoCodecType? {
+        switch mediaSubType {
+        case .hevc: return .hevc
+        case .h264: return .h264
+        case .jpeg: return .jpeg
+        case .proRes4444: return .proRes4444
+        case .proRes422: return .proRes422
+        case .proRes422HQ: return .proRes422HQ
+        case .proRes422LT: return .proRes422LT
+        case .proRes422Proxy: return .proRes422Proxy
+        case .hevcWithAlpha: return .hevcWithAlpha
+        default: return nil
+        }
+    }
+
+    var colorPrimaries: String? {
+        switch extensions[
+            kCMFormatDescriptionExtension_ColorPrimaries
+        ] as! CFString {
+        case kCMFormatDescriptionColorPrimaries_ITU_R_709_2: AVVideoColorPrimaries_ITU_R_709_2
+        #if os(macOS)
+        case kCMFormatDescriptionColorPrimaries_EBU_3213: AVVideoColorPrimaries_EBU_3213
+        #endif
+        case kCMFormatDescriptionColorPrimaries_SMPTE_C: AVVideoColorPrimaries_SMPTE_C
+        case kCMFormatDescriptionColorPrimaries_P3_D65: AVVideoColorPrimaries_P3_D65
+        case kCMFormatDescriptionColorPrimaries_ITU_R_2020: AVVideoColorPrimaries_ITU_R_2020
+        default: nil
+        }
+    }
+
+    var colorTransferFunction: String? {
+        switch extensions[
+            kCMFormatDescriptionExtension_TransferFunction
+        ] as! CFString {
+        case kCMFormatDescriptionTransferFunction_ITU_R_709_2: AVVideoTransferFunction_ITU_R_709_2
+        #if os(macOS)
+        case kCMFormatDescriptionTransferFunction_SMPTE_240M_1995: AVVideoTransferFunction_SMPTE_240M_1995
+        #endif
+        case kCMFormatDescriptionTransferFunction_SMPTE_ST_2084_PQ: AVVideoTransferFunction_SMPTE_ST_2084_PQ
+        case kCMFormatDescriptionTransferFunction_ITU_R_2100_HLG: AVVideoTransferFunction_ITU_R_2100_HLG
+        case kCMFormatDescriptionTransferFunction_Linear: AVVideoTransferFunction_Linear
+        default: nil
+        }
+    }
+
+    var colorYCbCrMatrix: String? {
+        switch extensions[
+            kCMFormatDescriptionExtension_YCbCrMatrix
+        ] as! CFString {
+        case kCMFormatDescriptionYCbCrMatrix_ITU_R_709_2: AVVideoYCbCrMatrix_ITU_R_709_2
+        case kCMFormatDescriptionYCbCrMatrix_ITU_R_601_4: AVVideoYCbCrMatrix_ITU_R_601_4
+        #if os(macOS)
+        case kCMFormatDescriptionYCbCrMatrix_SMPTE_240M_1995: AVVideoYCbCrMatrix_SMPTE_240M_1995
+        #endif
+        case kCMFormatDescriptionYCbCrMatrix_ITU_R_2020: AVVideoYCbCrMatrix_ITU_R_2020
+        default: nil
+        }
+    }
+}


### PR DESCRIPTION
- [x] Add a custom `UpscalingExportSession`
- [x] Split off `UpscalingExportSession` and `UpscalingCompositor` into a library
- [x] Maintain codec/color primaries/transfer function/ycbcr matrix (adds support for HDR video, codecs: h264, jpeg, proRes4444, proRes422, proRes422HQ, proRes422LT, proRes422Proxy, hevcWithAlpha)
- [x] Maintain video metadata
- [x] Support up to 16384x16384 resolution instead of 8k
- [x] Support upscaling multiple video tracks
- [x] Maintain video frame rate
- [ ] Maintain audio format
- [ ] Maintain non video/audio tracks (captions/metadata/...)
- [ ] Support video track transforms (maybe already working?)

closes #2 