### PR TITLE
Fix crash when upscaling spatial video to a non-HEVC codec

### DIFF
--- a/Sources/Upscaling/Extensions/AVVideoCodecType+Extensions.swift
+++ b/Sources/Upscaling/Extensions/AVVideoCodecType+Extensions.swift
@@ -15,4 +15,9 @@ public extension AVVideoCodecType {
         guard bytes.count == 4 else { return nil }
         return bytes.reduce(CMVideoCodecType(0)) { ($0 << 8) | CMVideoCodecType($1) }
     }
+
+    /// Whether this codec supports MV-HEVC (spatial video) encoding.
+    var supportsMultiviewHEVC: Bool {
+        self == .hevc
+    }
 }

--- a/Sources/Upscaling/UpscalingExportSession.swift
+++ b/Sources/Upscaling/UpscalingExportSession.swift
@@ -70,9 +70,19 @@ public class UpscalingExportSession {
             guard [.audio, .video].contains(track.mediaType) else { continue }
             let formatDescription = try await track.load(.formatDescriptions).first
 
+            if #available(macOS 14.0, iOS 17.0, *),
+               track.mediaType == .video,
+               formatDescription?.hasLeftAndRightEye ?? false {
+                let effectiveCodec = outputCodec ?? formatDescription?.videoCodecType ?? .hevc
+                guard effectiveCodec.supportsMultiviewHEVC else {
+                    throw Error.codecDoesNotSupportSpatialVideo(effectiveCodec)
+                }
+            }
+
             guard let assetReaderOutput = Self.assetReaderOutput(
                 for: track,
-                formatDescription: formatDescription
+                formatDescription: formatDescription,
+                outputCodec: outputCodec
             ),
                 let assetWriterInput = try await Self.assetWriterInput(
                     for: track,
@@ -99,7 +109,10 @@ public class UpscalingExportSession {
             } else if track.mediaType == .video {
                 progress.totalUnitCount += 10
                 if #available(macOS 14.0, iOS 17.0, *),
-                   formatDescription?.hasLeftAndRightEye ?? false {
+                   Self.shouldExportSpatialVideo(
+                       formatDescription: formatDescription,
+                       outputCodec: outputCodec
+                   ) {
                     try await mediaTracks.append(.spatialVideo(
                         assetReaderOutput,
                         assetWriterInput,
@@ -260,9 +273,22 @@ public class UpscalingExportSession {
         return supportedProperties[property as String] != nil
     }
 
+    /// Whether the export should produce an MV-HEVC (spatial) video: the source
+    /// must contain left and right eye layers and the output codec must support MV-HEVC.
+    @available(macOS 14.0, iOS 17.0, *)
+    private static func shouldExportSpatialVideo(
+        formatDescription: CMFormatDescription?,
+        outputCodec: AVVideoCodecType?
+    ) -> Bool {
+        guard formatDescription?.hasLeftAndRightEye ?? false else { return false }
+        let effectiveCodec = outputCodec ?? formatDescription?.videoCodecType ?? .hevc
+        return effectiveCodec.supportsMultiviewHEVC
+    }
+
     private static func assetReaderOutput(
         for track: AVAssetTrack,
-        formatDescription: CMFormatDescription?
+        formatDescription: CMFormatDescription?,
+        outputCodec: AVVideoCodecType?
     ) -> AVAssetReaderOutput? {
         switch track.mediaType {
         case .video:
@@ -270,7 +296,10 @@ public class UpscalingExportSession {
                 kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
             ]
             if #available(macOS 14.0, iOS 17.0, *),
-               formatDescription?.hasLeftAndRightEye ?? false {
+               shouldExportSpatialVideo(
+                   formatDescription: formatDescription,
+                   outputCodec: outputCodec
+               ) {
                 outputSettings[AVVideoDecompressionPropertiesKey] = [
                     kVTDecompressionPropertyKey_RequestedMVHEVCVideoLayerIDs: [0, 1]
                 ]
@@ -323,7 +352,10 @@ public class UpscalingExportSession {
                 compressionProperties[kVTCompressionPropertyKey_PrioritizeEncodingSpeedOverQuality] = true
             }
             if #available(macOS 14.0, iOS 17.0, *),
-               formatDescription?.hasLeftAndRightEye ?? false {
+               shouldExportSpatialVideo(
+                   formatDescription: formatDescription,
+                   outputCodec: outputCodec
+               ) {
                 compressionProperties[kVTCompressionPropertyKey_MVHEVCVideoLayerIDs] = [0, 1]
                 if let extensions = formatDescription?.extensions {
                     for key in [
@@ -583,5 +615,20 @@ public extension UpscalingExportSession {
         case missingTaggedBuffers
         case invalidTaggedBuffers
         case failedToCreateUpscaler
+        case codecDoesNotSupportSpatialVideo(AVVideoCodecType)
+    }
+}
+
+// MARK: - UpscalingExportSession.Error + LocalizedError
+
+extension UpscalingExportSession.Error: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .codecDoesNotSupportSpatialVideo(codec):
+            "The \(codec.rawValue) codec does not support spatial (MV-HEVC) video. " +
+                "Use the HEVC codec to preserve spatial video."
+        default:
+            "\(self)"
+        }
     }
 }

--- a/Sources/fx-upscale/FXUpscale.swift
+++ b/Sources/fx-upscale/FXUpscale.swift
@@ -58,8 +58,14 @@ import Upscaling
         default: .hevc
         }
 
+        // Spatial (MV-HEVC) video can only be encoded with HEVC, so never force ProRes for it.
+        var isSpatialVideo = false
+        if #available(macOS 14.0, iOS 17.0, *) {
+            isSpatialVideo = formatDescription?.hasLeftAndRightEye ?? false
+        }
+
         // Through anecdotal tests anything beyond 14.5K fails to encode for anything other than ProRes
-        let convertToProRes = (outputSize.width * outputSize.height) > (14500 * 8156)
+        let convertToProRes = !isSpatialVideo && (outputSize.width * outputSize.height) > (14500 * 8156)
 
         if convertToProRes {
             CommandLine.info("Forced ProRes conversion due to output size being larger than 14.5K (will fail otherwise)")


### PR DESCRIPTION
Upscaling an MV-HEVC (spatial) video with a non-HEVC codec crashed with `NSInvalidArgumentException` because the `MVHEVCVideoLayerIDs` compression property is only valid for HEVC.

Spatial layers are now only requested/written when the effective output codec supports MV-HEVC, and a clear `codecDoesNotSupportSpatialVideo` error is thrown otherwise. The CLI also no longer auto-switches spatial video to ProRes for large outputs.