### PR TITLE
Fix deadlock when upscaling spatial video

### DIFF
--- a/Sources/Upscaling/UpscalingExportSession.swift
+++ b/Sources/Upscaling/UpscalingExportSession.swift
@@ -521,7 +521,7 @@ public class UpscalingExportSession {
                     upscaledRight = $0
                     group.leave()
                 }
-                group.notify(queue: readerQueue) {
+                group.notify(queue: .global(qos: .userInitiated)) {
                     frame.fulfill((upscaledLeft!, upscaledRight!))
                 }
             }


### PR DESCRIPTION
Upscaling a spatial (MV-HEVC) video hangs at 0% and produces an empty file.

The reader loop runs on a serial queue, but each frame's GPU results are fulfilled via `group.notify(queue: readerQueue)` on that same serial queue. Once the reader loop blocks on `channel.enqueue` at capacity, those notify blocks can never run, so frames are never fulfilled and the writer waits forever.

Fulfill the frame on a global queue instead so it isn't serialized behind the blocked reader loop.