### PR TITLE
Unify video export pipeline and bridge sample writing to async/await

### DIFF
--- a/Sources/Upscaling/UpscalingExportSession.swift
+++ b/Sources/Upscaling/UpscalingExportSession.swift
@@ -64,7 +64,7 @@ public class UpscalingExportSession {
 
         let duration = try await asset.load(.duration)
 
-        var mediaTracks: [MediaTrack] = []
+        var mediaTracks: [MediaTrackTask] = []
         let tracks = try await asset.load(.tracks)
         for track in tracks {
             guard [.audio, .video].contains(track.mediaType) else { continue }
@@ -106,45 +106,104 @@ public class UpscalingExportSession {
 
             if track.mediaType == .audio {
                 progress.totalUnitCount += 1
-                mediaTracks.append(.audio(assetReaderOutput, assetWriterInput))
+                mediaTracks.append(MediaTrackTask(pendingUnitCount: 1) { progress in
+                    try await Self.copyAudioSamples(from: assetReaderOutput, to: assetWriterInput, progress: progress)
+                })
             } else if track.mediaType == .video {
                 progress.totalUnitCount += 10
+                let inputSize = try await track.load(.naturalSize)
+                let outputSize = outputSize
+                let sourcePixelBufferAttributes: [String: Any] = [
+                    kCVPixelBufferPixelFormatTypeKey as String: pixelFormat,
+                    kCVPixelBufferMetalCompatibilityKey as String: true,
+                    kCVPixelBufferWidthKey as String: outputSize.width,
+                    kCVPixelBufferHeightKey as String: outputSize.height
+                ]
                 if #available(macOS 14.0, iOS 17.0, *),
                    Self.shouldExportSpatialVideo(
                        formatDescription: formatDescription,
                        outputCodec: outputCodec
                    ) {
-                    try await mediaTracks.append(.spatialVideo(
-                        assetReaderOutput,
-                        assetWriterInput,
-                        track.load(.naturalSize),
-                        pixelFormat,
-                        AVAssetWriterInputTaggedPixelBufferGroupAdaptor(
-                            assetWriterInput: assetWriterInput,
-                            sourcePixelBufferAttributes: [
-                                kCVPixelBufferPixelFormatTypeKey as String: pixelFormat,
-                                kCVPixelBufferMetalCompatibilityKey as String: true,
-                                kCVPixelBufferWidthKey as String: outputSize.width,
-                                kCVPixelBufferHeightKey as String: outputSize.height
-                            ]
+                    let adaptor = AVAssetWriterInputTaggedPixelBufferGroupAdaptor(
+                        assetWriterInput: assetWriterInput,
+                        sourcePixelBufferAttributes: sourcePixelBufferAttributes
+                    )
+                    mediaTracks.append(MediaTrackTask(pendingUnitCount: 10) { progress in
+                        try await Self.processVideoSamples(
+                            from: assetReaderOutput,
+                            to: assetWriterInput,
+                            inputSize: inputSize,
+                            outputSize: outputSize,
+                            pixelFormat: pixelFormat,
+                            progress: progress,
+                            label: "\(String(describing: Self.self)).spatialvideo",
+                            decode: { sampleBuffer -> (left: CVPixelBuffer, right: CVPixelBuffer) in
+                                try Self.stereoscopicPixelBuffers(from: sampleBuffer)
+                            },
+                            submitUpscale: { upscaler, frame, completion in
+                                let group = DispatchGroup()
+                                var left: CVPixelBuffer?
+                                var right: CVPixelBuffer?
+                                group.enter()
+                                upscaler.upscale(frame.left, pixelBufferPool: adaptor.pixelBufferPool) {
+                                    left = $0
+                                    group.leave()
+                                }
+                                group.enter()
+                                upscaler.upscale(frame.right, pixelBufferPool: adaptor.pixelBufferPool) {
+                                    right = $0
+                                    group.leave()
+                                }
+                                group.notify(queue: .global(qos: .userInitiated)) {
+                                    completion((left: left!, right: right!))
+                                }
+                            },
+                            append: { frame, time in
+                                adaptor.appendTaggedBuffers([
+                                    CMTaggedBuffer(
+                                        tags: [.stereoView(.leftEye), .videoLayerID(0)],
+                                        pixelBuffer: frame.left
+                                    ),
+                                    CMTaggedBuffer(
+                                        tags: [.stereoView(.rightEye), .videoLayerID(1)],
+                                        pixelBuffer: frame.right
+                                    )
+                                ], withPresentationTime: time)
+                            }
                         )
-                    ))
+                    })
                 } else {
-                    try await mediaTracks.append(.video(
-                        assetReaderOutput,
-                        assetWriterInput,
-                        track.load(.naturalSize),
-                        pixelFormat,
-                        AVAssetWriterInputPixelBufferAdaptor(
-                            assetWriterInput: assetWriterInput,
-                            sourcePixelBufferAttributes: [
-                                kCVPixelBufferPixelFormatTypeKey as String: pixelFormat,
-                                kCVPixelBufferMetalCompatibilityKey as String: true,
-                                kCVPixelBufferWidthKey as String: outputSize.width,
-                                kCVPixelBufferHeightKey as String: outputSize.height
-                            ]
+                    let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+                        assetWriterInput: assetWriterInput,
+                        sourcePixelBufferAttributes: sourcePixelBufferAttributes
+                    )
+                    mediaTracks.append(MediaTrackTask(pendingUnitCount: 10) { progress in
+                        try await Self.processVideoSamples(
+                            from: assetReaderOutput,
+                            to: assetWriterInput,
+                            inputSize: inputSize,
+                            outputSize: outputSize,
+                            pixelFormat: pixelFormat,
+                            progress: progress,
+                            label: "\(String(describing: Self.self)).video",
+                            decode: { sampleBuffer -> CVPixelBuffer in
+                                guard let imageBuffer = sampleBuffer.imageBuffer else {
+                                    throw Error.missingImageBuffer
+                                }
+                                return imageBuffer
+                            },
+                            submitUpscale: { upscaler, frame, completion in
+                                upscaler.upscale(
+                                    frame,
+                                    pixelBufferPool: adaptor.pixelBufferPool,
+                                    completionHandler: completion
+                                )
+                            },
+                            append: { frame, time in
+                                adaptor.append(frame, withPresentationTime: time)
+                            }
                         )
-                    ))
+                    })
                 }
             }
         }
@@ -160,38 +219,9 @@ public class UpscalingExportSession {
                 for mediaTrack in mediaTracks {
                     group.addTask { [weak self] in
                         guard let self else { return }
-                        switch mediaTrack {
-                        case let .audio(output, input):
-                            let progress = Progress(totalUnitCount: Int64(duration.seconds))
-                            self.progress.addChild(progress, withPendingUnitCount: 1)
-                            try await Self.processAudioSamples(from: output, to: input, progress: progress)
-                        case let .video(output, input, inputSize, pixelFormat, adaptor):
-                            let progress = Progress(totalUnitCount: Int64(duration.seconds))
-                            self.progress.addChild(progress, withPendingUnitCount: 10)
-                            try await Self.processVideoSamples(
-                                from: output,
-                                to: input,
-                                adaptor: adaptor,
-                                inputSize: inputSize,
-                                outputSize: outputSize,
-                                pixelFormat: pixelFormat,
-                                progress: progress
-                            )
-                        case let .spatialVideo(output, input, inputSize, pixelFormat, adaptor):
-                            if #available(macOS 14.0, iOS 17.0, *) {
-                                let progress = Progress(totalUnitCount: Int64(duration.seconds))
-                                self.progress.addChild(progress, withPendingUnitCount: 10)
-                                try await Self.processSpatialVideoSamples(
-                                    from: output,
-                                    to: input,
-                                    adaptor: adaptor as! AVAssetWriterInputTaggedPixelBufferGroupAdaptor,
-                                    inputSize: inputSize,
-                                    outputSize: outputSize,
-                                    pixelFormat: pixelFormat,
-                                    progress: progress
-                                )
-                            }
-                        }
+                        let progress = Progress(totalUnitCount: Int64(duration.seconds))
+                        self.progress.addChild(progress, withPendingUnitCount: mediaTrack.pendingUnitCount)
+                        try await mediaTrack.process(progress)
                     }
                 }
                 try await group.waitForAll()
@@ -239,26 +269,16 @@ public class UpscalingExportSession {
 
     // MARK: Private
 
-    private enum MediaTrack {
-        case audio(
-            _ output: AVAssetReaderOutput,
-            _ input: AVAssetWriterInput
-        )
-        case video(
-            _ output: AVAssetReaderOutput,
-            _ input: AVAssetWriterInput,
-            _ inputSize: CGSize,
-            _ pixelFormat: OSType,
-            _ adaptor: AVAssetWriterInputPixelBufferAdaptor
-        )
-        case spatialVideo(
-            _ output: AVAssetReaderOutput,
-            _ input: AVAssetWriterInput,
-            _ inputSize: CGSize,
-            _ pixelFormat: OSType,
-            _ adaptor: NSObject
-        )
+    /// A single track's export work, ready to run against a child `Progress`.
+    /// Storing a prebuilt closure (rather than the reader/writer/adaptor) keeps
+    /// availability-gated types (e.g. the spatial adaptor) out of this type and
+    /// lets the task group treat every track uniformly.
+    private struct MediaTrackTask {
+        let pendingUnitCount: Int64
+        let process: (_ progress: Progress) async throws -> Void
     }
+
+    private static let maxFramesInFlight = 3
 
     private static func encoder(
         _ codec: AVVideoCodecType,
@@ -282,8 +302,7 @@ public class UpscalingExportSession {
 
     /// Whether the export should produce an MV-HEVC (spatial) video: the source
     /// must contain left and right eye layers and the output codec must support MV-HEVC.
-    @available(macOS 14.0, iOS 17.0, *)
-    private static func shouldExportSpatialVideo(
+    @available(macOS 14.0, iOS 17.0, *) private static func shouldExportSpatialVideo(
         formatDescription: CMFormatDescription?,
         outputCodec: AVVideoCodecType?
     ) -> Bool {
@@ -416,50 +435,42 @@ public class UpscalingExportSession {
         }
     }
 
-    private static func processAudioSamples(
-        from assetReaderOutput: AVAssetReaderOutput,
-        to assetWriterInput: AVAssetWriterInput,
+    private static func copyAudioSamples(
+        from output: AVAssetReaderOutput,
+        to input: AVAssetWriterInput,
         progress: Progress
     ) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            let queue = DispatchQueue(
-                label: "\(String(describing: Self.self)).audio.\(UUID().uuidString)",
-                qos: .userInitiated
-            )
-            assetWriterInput.requestMediaDataWhenReady(on: queue) {
-                while assetWriterInput.isReadyForMoreMediaData {
-                    if let nextSampleBuffer = assetReaderOutput.copyNextSampleBuffer() {
-                        if nextSampleBuffer.presentationTimeStamp.isNumeric {
-                            let timestamp = Int64(nextSampleBuffer.presentationTimeStamp.seconds)
-                            DispatchQueue.main.async {
-                                progress.completedUnitCount = timestamp
-                            }
-                        }
-                        guard assetWriterInput.append(nextSampleBuffer) else {
-                            assetWriterInput.markAsFinished()
-                            continuation.resume()
-                            return
-                        }
-                    } else {
-                        assetWriterInput.markAsFinished()
-                        continuation.resume()
-                        return
-                    }
-                }
+        try await input.appendSamples(label: "\(String(describing: Self.self)).audio") {
+            guard let sampleBuffer = output.copyNextSampleBuffer() else { return false }
+            if sampleBuffer.presentationTimeStamp.isNumeric {
+                let timestamp = Int64(sampleBuffer.presentationTimeStamp.seconds)
+                DispatchQueue.main.async { progress.completedUnitCount = timestamp }
             }
-        } as Void
+            return input.append(sampleBuffer)
+        }
     }
 
-    private static let maxFramesInFlight = 3
-
-    private static func processVideoSamples(
-        from assetReaderOutput: AVAssetReaderOutput,
-        to assetWriterInput: AVAssetWriterInput,
-        adaptor: AVAssetWriterInputPixelBufferAdaptor,
+    /// Reads frames from `output`, upscales them off the reader thread with at
+    /// most `maxFramesInFlight` outstanding, and appends the results to `input`
+    /// in presentation order. The small differences between plain and spatial
+    /// video live in the injected closures:
+    ///
+    /// - `decode` extracts the input pixel buffer(s) for one frame.
+    /// - `submitUpscale` submits GPU work (synchronously, in order, on the
+    ///   reader thread) and calls its completion with the upscaled frame.
+    /// - `append` writes one upscaled frame, returning `false` if the writer
+    ///   rejected it.
+    private static func processVideoSamples<Frame>(
+        from output: AVAssetReaderOutput,
+        to input: AVAssetWriterInput,
         inputSize: CGSize,
         outputSize: CGSize,
         pixelFormat: OSType,
-        progress: Progress
+        progress: Progress,
+        label: String,
+        decode: @escaping (CMSampleBuffer) throws -> Frame,
+        submitUpscale: @escaping (Upscaler, Frame, @escaping (Frame) -> Void) -> Void,
+        append: @escaping (Frame, CMTime) -> Bool
     ) async throws {
         guard let upscaler = Upscaler(
             inputSize: inputSize,
@@ -469,174 +480,106 @@ public class UpscalingExportSession {
             throw Error.failedToCreateUpscaler
         }
 
-        let channel = FrameChannel<CVPixelBuffer>(capacity: maxFramesInFlight)
+        let channel = FrameChannel<Frame>(capacity: maxFramesInFlight)
 
-        DispatchQueue(
-            label: "\(String(describing: Self.self)).video.read.\(UUID().uuidString)",
-            qos: .userInitiated
-        ).async {
-            while let sampleBuffer = assetReaderOutput.copyNextSampleBuffer() {
-                guard let imageBuffer = sampleBuffer.imageBuffer else {
-                    channel.finish(throwing: Error.missingImageBuffer)
+        // Decode and submit GPU work in presentation order on a dedicated thread.
+        // `enqueue` blocks once `maxFramesInFlight` frames are outstanding, which
+        // bounds memory and keeps decode, upscaling, and encoding overlapping.
+        DispatchQueue(label: "\(label).read", qos: .userInitiated).async {
+            while let sampleBuffer = output.copyNextSampleBuffer() {
+                do {
+                    let inputFrame = try decode(sampleBuffer)
+                    let frame = FrameChannel<Frame>.PendingFrame(time: sampleBuffer.presentationTimeStamp)
+                    guard channel.enqueue(frame) else { return }
+                    submitUpscale(upscaler, inputFrame) { frame.fulfill($0) }
+                } catch {
+                    channel.finish(throwing: error)
                     return
-                }
-                let frame = FrameChannel<CVPixelBuffer>.PendingFrame(
-                    time: sampleBuffer.presentationTimeStamp
-                )
-                guard channel.enqueue(frame) else { return }
-                upscaler.upscale(imageBuffer, pixelBufferPool: adaptor.pixelBufferPool) { upscaled in
-                    frame.fulfill(upscaled)
                 }
             }
             channel.finish()
         }
 
-        try await withCheckedThrowingContinuation { continuation in
-            let queue = DispatchQueue(
-                label: "\(String(describing: Self.self)).video.write.\(UUID().uuidString)",
-                qos: .userInitiated
-            )
-            assetWriterInput.requestMediaDataWhenReady(on: queue) {
-                while assetWriterInput.isReadyForMoreMediaData {
-                    guard let frame = channel.dequeue() else {
-                        assetWriterInput.markAsFinished()
-                        if let error = channel.terminationError {
-                            continuation.resume(throwing: error)
-                        } else {
-                            continuation.resume()
-                        }
-                        return
-                    }
-                    let upscaledImageBuffer = frame.wait()
-                    if frame.time.isNumeric {
-                        let timestamp = Int64(frame.time.seconds)
-                        DispatchQueue.main.async { progress.completedUnitCount = timestamp }
-                    }
-                    guard adaptor.append(
-                        upscaledImageBuffer,
-                        withPresentationTime: frame.time
-                    ) else {
-                        assetWriterInput.markAsFinished()
-                        channel.abort()
-                        continuation.resume()
-                        return
-                    }
+        // Append upscaled frames in order, waiting on each frame's GPU completion.
+        try await input.appendSamples(label: "\(label).write") {
+            guard let frame = channel.dequeue() else {
+                if let error = channel.terminationError {
+                    throw error
                 }
+                return false
             }
-        } as Void
+            let upscaledFrame = frame.wait()
+            if frame.time.isNumeric {
+                let timestamp = Int64(frame.time.seconds)
+                DispatchQueue.main.async { progress.completedUnitCount = timestamp }
+            }
+            guard append(upscaledFrame, frame.time) else {
+                channel.abort()
+                return false
+            }
+            return true
+        }
     }
 
-    @available(macOS 14.0, iOS 17.0, *) private static func processSpatialVideoSamples(
-        from assetReaderOutput: AVAssetReaderOutput,
-        to assetWriterInput: AVAssetWriterInput,
-        adaptor: AVAssetWriterInputTaggedPixelBufferGroupAdaptor,
-        inputSize: CGSize,
-        outputSize: CGSize,
-        pixelFormat: OSType,
-        progress: Progress
-    ) async throws {
-        guard let upscaler = Upscaler(
-            inputSize: inputSize,
-            outputSize: outputSize,
-            pixelFormat: pixelFormat
-        ) else {
-            throw Error.failedToCreateUpscaler
+    /// Extracts the left- and right-eye pixel buffers from a stereoscopic
+    /// (MV-HEVC) sample buffer.
+    @available(macOS 14.0, iOS 17.0, *) private static func stereoscopicPixelBuffers(
+        from sampleBuffer: CMSampleBuffer
+    ) throws -> (left: CVPixelBuffer, right: CVPixelBuffer) {
+        guard let taggedBuffers = sampleBuffer.taggedBuffers else {
+            throw Error.missingTaggedBuffers
         }
-
-        let channel = FrameChannel<(CVPixelBuffer, CVPixelBuffer)>(capacity: maxFramesInFlight)
-
-        let readerQueue = DispatchQueue(
-            label: "\(String(describing: Self.self)).spatialvideo.read.\(UUID().uuidString)",
-            qos: .userInitiated
-        )
-        readerQueue.async {
-            while let sampleBuffer = assetReaderOutput.copyNextSampleBuffer() {
-                guard let taggedBuffers = sampleBuffer.taggedBuffers else {
-                    channel.finish(throwing: Error.missingTaggedBuffers)
-                    return
-                }
-                let leftEyeBuffer = taggedBuffers.first(where: {
-                    $0.tags.first(matchingCategory: .stereoView) == .stereoView(.leftEye)
-                })?.buffer
-                let rightEyeBuffer = taggedBuffers.first(where: {
-                    $0.tags.first(matchingCategory: .stereoView) == .stereoView(.rightEye)
-                })?.buffer
-                guard let leftEyeBuffer,
-                      let rightEyeBuffer,
-                      case let .pixelBuffer(leftEyePixelBuffer) = leftEyeBuffer,
-                      case let .pixelBuffer(rightEyePixelBuffer) = rightEyeBuffer else {
-                    channel.finish(throwing: Error.invalidTaggedBuffers)
-                    return
-                }
-                let frame = FrameChannel<(CVPixelBuffer, CVPixelBuffer)>.PendingFrame(
-                    time: sampleBuffer.presentationTimeStamp
-                )
-                guard channel.enqueue(frame) else { return }
-                let group = DispatchGroup()
-                var upscaledLeft: CVPixelBuffer?
-                var upscaledRight: CVPixelBuffer?
-                group.enter()
-                upscaler.upscale(leftEyePixelBuffer, pixelBufferPool: adaptor.pixelBufferPool) {
-                    upscaledLeft = $0
-                    group.leave()
-                }
-                group.enter()
-                upscaler.upscale(rightEyePixelBuffer, pixelBufferPool: adaptor.pixelBufferPool) {
-                    upscaledRight = $0
-                    group.leave()
-                }
-                group.notify(queue: .global(qos: .userInitiated)) {
-                    frame.fulfill((upscaledLeft!, upscaledRight!))
-                }
-            }
-            channel.finish()
+        let leftBuffer = taggedBuffers.first {
+            $0.tags.first(matchingCategory: .stereoView) == .stereoView(.leftEye)
+        }?.buffer
+        let rightBuffer = taggedBuffers.first {
+            $0.tags.first(matchingCategory: .stereoView) == .stereoView(.rightEye)
+        }?.buffer
+        guard let leftBuffer, let rightBuffer,
+              case let .pixelBuffer(leftPixelBuffer) = leftBuffer,
+              case let .pixelBuffer(rightPixelBuffer) = rightBuffer else {
+            throw Error.invalidTaggedBuffers
         }
-
-        try await withCheckedThrowingContinuation { continuation in
-            let queue = DispatchQueue(
-                label: "\(String(describing: Self.self)).spatialvideo.write.\(UUID().uuidString)",
-                qos: .userInitiated
-            )
-            assetWriterInput.requestMediaDataWhenReady(on: queue) {
-                while assetWriterInput.isReadyForMoreMediaData {
-                    guard let frame = channel.dequeue() else {
-                        assetWriterInput.markAsFinished()
-                        if let error = channel.terminationError {
-                            continuation.resume(throwing: error)
-                        } else {
-                            continuation.resume()
-                        }
-                        return
-                    }
-                    let (upscaledLeftEyePixelBuffer, upscaledRightEyePixelBuffer) = frame.wait()
-                    if frame.time.isNumeric {
-                        let timestamp = Int64(frame.time.seconds)
-                        DispatchQueue.main.async { progress.completedUnitCount = timestamp }
-                    }
-                    let leftEyeTaggedBuffer = CMTaggedBuffer(
-                        tags: [.stereoView(.leftEye), .videoLayerID(0)],
-                        pixelBuffer: upscaledLeftEyePixelBuffer
-                    )
-                    let rightEyeTaggedBuffer = CMTaggedBuffer(
-                        tags: [.stereoView(.rightEye), .videoLayerID(1)],
-                        pixelBuffer: upscaledRightEyePixelBuffer
-                    )
-                    guard adaptor.appendTaggedBuffers(
-                        [leftEyeTaggedBuffer, rightEyeTaggedBuffer],
-                        withPresentationTime: frame.time
-                    ) else {
-                        assetWriterInput.markAsFinished()
-                        channel.abort()
-                        continuation.resume()
-                        return
-                    }
-                }
-            }
-        } as Void
+        return (leftPixelBuffer, rightPixelBuffer)
     }
 }
 
-// MARK: UpscalingExportSession.Error
+// MARK: - AVAssetWriterInput + async sample appending
+
+private extension AVAssetWriterInput {
+    /// Bridges the pull-based `requestMediaDataWhenReady(on:)` callback to
+    /// async/await.
+    ///
+    /// `appendNextSample` is invoked repeatedly on a private serial queue while
+    /// the input is ready for more data. It should append the next sample and
+    /// return `true`, or return `false` once the source is exhausted or the
+    /// writer stops accepting samples. Throwing propagates out of `await`. In
+    /// every terminating case the input is marked as finished.
+    func appendSamples(
+        label: String,
+        _ appendNextSample: @escaping () throws -> Bool
+    ) async throws {
+        let queue = DispatchQueue(label: label, qos: .userInitiated)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Swift.Error>) in
+            requestMediaDataWhenReady(on: queue) {
+                do {
+                    while self.isReadyForMoreMediaData {
+                        guard try appendNextSample() else {
+                            self.markAsFinished()
+                            continuation.resume()
+                            return
+                        }
+                    }
+                } catch {
+                    self.markAsFinished()
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - UpscalingExportSession.Error
 
 public extension UpscalingExportSession {
     enum Error: Swift.Error {

--- a/Tests/UpscalingTests/TestMedia.swift
+++ b/Tests/UpscalingTests/TestMedia.swift
@@ -1,0 +1,273 @@
+import AVFoundation
+import CoreMedia
+import CoreVideo
+import Foundation
+
+// MARK: - TestMedia
+
+/// Synthesizes small `.mov` files on disk so the export pipeline can be tested
+/// end to end without checking in binary fixtures.
+enum TestMedia {
+    // MARK: Internal
+
+    struct Options {
+        var size = CGSize(width: 160, height: 120)
+        var frameCount = 24
+        var fps: Int32 = 24
+        var transform: CGAffineTransform = .identity
+        var includeAudio = false
+        var metadata: [AVMetadataItem] = []
+    }
+
+    enum Failure: Error {
+        case cannotAddInput
+        case writeFailed
+        case pixelBufferFailed
+        case videoSampleFailed
+        case audioSetup
+        case audioSampleFailed
+    }
+
+    /// Writes a video (optionally with a silent LPCM audio track) to a unique
+    /// temporary URL and returns it.
+    static func makeVideo(_ options: Options = Options()) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fx-upscale-test-\(UUID().uuidString)")
+            .appendingPathExtension("mov")
+
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mov)
+        if !options.metadata.isEmpty {
+            writer.metadata = options.metadata
+        }
+
+        let videoInput = AVAssetWriterInput(mediaType: .video, outputSettings: [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: Int(options.size.width),
+            AVVideoHeightKey: Int(options.size.height)
+        ])
+        videoInput.expectsMediaDataInRealTime = false
+        videoInput.transform = options.transform
+        guard writer.canAdd(videoInput) else { throw Failure.cannotAddInput }
+        writer.add(videoInput)
+
+        let sampleRate = 44100.0
+        var audioInput: AVAssetWriterInput?
+        var audioFormat: CMAudioFormatDescription?
+        if options.includeAudio {
+            var asbd = AudioStreamBasicDescription(
+                mSampleRate: sampleRate,
+                mFormatID: kAudioFormatLinearPCM,
+                mFormatFlags: kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked,
+                mBytesPerPacket: 2,
+                mFramesPerPacket: 1,
+                mBytesPerFrame: 2,
+                mChannelsPerFrame: 1,
+                mBitsPerChannel: 16,
+                mReserved: 0
+            )
+            guard CMAudioFormatDescriptionCreate(
+                allocator: kCFAllocatorDefault,
+                asbd: &asbd,
+                layoutSize: 0,
+                layout: nil,
+                magicCookieSize: 0,
+                magicCookie: nil,
+                extensions: nil,
+                formatDescriptionOut: &audioFormat
+            ) == noErr, let audioFormat else { throw Failure.audioSetup }
+            let input = AVAssetWriterInput(
+                mediaType: .audio,
+                outputSettings: [
+                    AVFormatIDKey: kAudioFormatLinearPCM,
+                    AVSampleRateKey: sampleRate,
+                    AVNumberOfChannelsKey: 1,
+                    AVLinearPCMBitDepthKey: 16,
+                    AVLinearPCMIsBigEndianKey: false,
+                    AVLinearPCMIsFloatKey: false,
+                    AVLinearPCMIsNonInterleaved: false
+                ]
+            )
+            input.expectsMediaDataInRealTime = false
+            guard writer.canAdd(input) else { throw Failure.cannotAddInput }
+            writer.add(input)
+            audioInput = input
+        }
+
+        guard writer.startWriting() else { throw writer.error ?? Failure.writeFailed }
+        writer.startSession(atSourceTime: .zero)
+
+        for index in 0..<options.frameCount {
+            let time = CMTime(value: CMTimeValue(index), timescale: options.fps)
+            let pixelBuffer = try makePixelBuffer(size: options.size, frameIndex: index)
+            while !videoInput.isReadyForMoreMediaData {
+                usleep(500)
+            }
+            guard let sampleBuffer = makeVideoSampleBuffer(pixelBuffer, at: time, fps: options.fps) else {
+                throw Failure.videoSampleFailed
+            }
+            guard videoInput.append(sampleBuffer) else { throw writer.error ?? Failure.writeFailed }
+        }
+        videoInput.markAsFinished()
+
+        if let audioInput, let audioFormat {
+            let framesPerChunk = Int(sampleRate) / Int(options.fps)
+            for index in 0..<options.frameCount {
+                let time = CMTime(value: CMTimeValue(index * framesPerChunk), timescale: CMTimeScale(sampleRate))
+                guard let sampleBuffer = makeSilentAudioBuffer(
+                    at: time,
+                    sampleRate: sampleRate,
+                    frameCount: framesPerChunk,
+                    format: audioFormat
+                ) else { throw Failure.audioSampleFailed }
+                while !audioInput.isReadyForMoreMediaData {
+                    usleep(500)
+                }
+                guard audioInput.append(sampleBuffer) else { throw writer.error ?? Failure.writeFailed }
+            }
+            audioInput.markAsFinished()
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        writer.finishWriting { semaphore.signal() }
+        semaphore.wait()
+        if writer.status != .completed {
+            throw writer.error ?? Failure.writeFailed
+        }
+        return url
+    }
+
+    // MARK: Private
+
+    private static func makePixelBuffer(size: CGSize, frameIndex: Int) throws -> CVPixelBuffer {
+        var pixelBuffer: CVPixelBuffer?
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            Int(size.width),
+            Int(size.height),
+            kCVPixelFormatType_32BGRA,
+            [kCVPixelBufferCGImageCompatibilityKey: true,
+             kCVPixelBufferCGBitmapContextCompatibilityKey: true] as CFDictionary,
+            &pixelBuffer
+        )
+        guard status == kCVReturnSuccess, let pixelBuffer else { throw Failure.pixelBufferFailed }
+        CVPixelBufferLockBaseAddress(pixelBuffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, []) }
+        if let base = CVPixelBufferGetBaseAddress(pixelBuffer) {
+            // A moving diagonal stripe so frames differ and upscaling has detail.
+            let width = CVPixelBufferGetWidth(pixelBuffer)
+            let height = CVPixelBufferGetHeight(pixelBuffer)
+            let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+            let pixels = base.assumingMemoryBound(to: UInt8.self)
+            for y in 0..<height {
+                for x in 0..<width {
+                    let offset = y * bytesPerRow + x * 4
+                    let on = ((x + y + frameIndex) / 8) % 2 == 0
+                    pixels[offset + 0] = on ? 220 : 30 // B
+                    pixels[offset + 1] = UInt8((x * 255) / max(width, 1)) // G
+                    pixels[offset + 2] = UInt8((y * 255) / max(height, 1)) // R
+                    pixels[offset + 3] = 255 // A
+                }
+            }
+        }
+        return pixelBuffer
+    }
+
+    private static func makeVideoSampleBuffer(
+        _ pixelBuffer: CVPixelBuffer,
+        at time: CMTime,
+        fps: Int32
+    ) -> CMSampleBuffer? {
+        var formatDescription: CMVideoFormatDescription?
+        guard CMVideoFormatDescriptionCreateForImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            formatDescriptionOut: &formatDescription
+        ) == noErr, let formatDescription else { return nil }
+        var timing = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: fps),
+            presentationTimeStamp: time,
+            decodeTimeStamp: .invalid
+        )
+        var sampleBuffer: CMSampleBuffer?
+        guard CMSampleBufferCreateReadyWithImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            formatDescription: formatDescription,
+            sampleTiming: &timing,
+            sampleBufferOut: &sampleBuffer
+        ) == noErr else { return nil }
+        return sampleBuffer
+    }
+
+    private static func makeSilentAudioBuffer(
+        at time: CMTime,
+        sampleRate: Double,
+        frameCount: Int,
+        format: CMAudioFormatDescription
+    ) -> CMSampleBuffer? {
+        let bytesPerFrame = 2
+        let dataLength = frameCount * bytesPerFrame
+        var blockBuffer: CMBlockBuffer?
+        guard CMBlockBufferCreateWithMemoryBlock(
+            allocator: kCFAllocatorDefault,
+            memoryBlock: nil,
+            blockLength: dataLength,
+            blockAllocator: kCFAllocatorDefault,
+            customBlockSource: nil,
+            offsetToData: 0,
+            dataLength: dataLength,
+            flags: kCMBlockBufferAssureMemoryNowFlag,
+            blockBufferOut: &blockBuffer
+        ) == noErr, let blockBuffer else { return nil }
+        CMBlockBufferFillDataBytes(with: 0, blockBuffer: blockBuffer, offsetIntoDestination: 0, dataLength: dataLength)
+        var timing = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: CMTimeScale(sampleRate)),
+            presentationTimeStamp: time,
+            decodeTimeStamp: .invalid
+        )
+        var sampleSize = bytesPerFrame
+        var sampleBuffer: CMSampleBuffer?
+        guard CMSampleBufferCreateReady(
+            allocator: kCFAllocatorDefault,
+            dataBuffer: blockBuffer,
+            formatDescription: format,
+            sampleCount: frameCount,
+            sampleTimingEntryCount: 1,
+            sampleTimingArray: &timing,
+            sampleSizeEntryCount: 1,
+            sampleSizeArray: &sampleSize,
+            sampleBufferOut: &sampleBuffer
+        ) == noErr else { return nil }
+        return sampleBuffer
+    }
+}
+
+// MARK: - Inspection helpers
+
+extension AVAsset {
+    func videoDimensions() async throws -> CGSize? {
+        guard let track = try await loadTracks(withMediaType: .video).first,
+              let formatDescription = try await track.load(.formatDescriptions).first else { return nil }
+        let dimensions = CMVideoFormatDescriptionGetDimensions(formatDescription)
+        return CGSize(width: Int(dimensions.width), height: Int(dimensions.height))
+    }
+
+    /// Counts decoded frames. Decoding (rather than reading compressed samples)
+    /// yields exactly one buffer per presentation frame.
+    func videoFrameCount() async throws -> Int {
+        guard let track = try await loadTracks(withMediaType: .video).first else { return 0 }
+        let reader = try AVAssetReader(asset: self)
+        let output = AVAssetReaderTrackOutput(
+            track: track,
+            outputSettings: [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+        )
+        output.alwaysCopiesSampleData = false
+        reader.add(output)
+        reader.startReading()
+        var count = 0
+        while output.copyNextSampleBuffer() != nil {
+            count += 1
+        }
+        return count
+    }
+}

--- a/Tests/UpscalingTests/UpscalingTests.swift
+++ b/Tests/UpscalingTests/UpscalingTests.swift
@@ -1,54 +1,236 @@
+import AVFoundation
 import CoreImage
+import CoreMedia
 import MetalFX
+import Testing
 @testable import Upscaling
-import XCTest
 
-final class UpscalingTests: XCTestCase {
-    func testBasicUpscale() async throws {
-        // basic upscale
-        throw XCTSkip("unimplemented")
+/// Each test runs a full export, whose reader/writer block real dispatch threads;
+/// run serially so concurrent exports can't exhaust the thread pool.
+@Suite(.serialized) struct UpscalingTests {
+    // MARK: Pipeline
+
+    @Test func basicUpscale() async throws {
+        let source = try TestMedia.makeVideo(.init(frameCount: 24))
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let outputSize = CGSize(width: 320, height: 240)
+        let session = UpscalingExportSession(
+            asset: AVAsset(url: source),
+            preferredOutputURL: source.renamed { "\($0) Upscaled" },
+            outputSize: outputSize
+        )
+        defer { try? FileManager.default.removeItem(at: session.outputURL) }
+
+        try await session.export()
+
+        #expect(FileManager.default.fileExists(atPath: session.outputURL.path))
+        let output = AVAsset(url: session.outputURL)
+        let dimensions = try await output.videoDimensions()
+        #expect(dimensions == outputSize)
+        // Every input frame must be preserved, exactly once.
+        let sourceFrames = try await AVAsset(url: source).videoFrameCount()
+        let outputFrames = try await output.videoFrameCount()
+        #expect(sourceFrames == 24, "generator sanity")
+        #expect(outputFrames == sourceFrames)
+    }
+
+    @Test func defaultCodecMatchesSource() async throws {
+        let source = try TestMedia.makeVideo()
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let session = UpscalingExportSession(
+            asset: AVAsset(url: source),
+            preferredOutputURL: source.renamed { "\($0) Out" },
+            outputSize: CGSize(width: 320, height: 240)
+        )
+        defer { try? FileManager.default.removeItem(at: session.outputURL) }
+        try await session.export()
+
+        let track = try await AVAsset(url: session.outputURL).loadTracks(withMediaType: .video).first
+        let format = try await track?.load(.formatDescriptions).first
+        #expect(format?.mediaSubType == .h264)
     }
 
     /// https://github.com/finnvoor/fx-upscale/issues/8
-    func testUpscaleTransformedVideo() async throws {
-        // make sure transform is applied to upscaled video
-        throw XCTSkip("unimplemented")
+    @Test func upscaleTransformedVideo() async throws {
+        let transform = CGAffineTransform(rotationAngle: .pi / 2)
+        let source = try TestMedia.makeVideo(.init(transform: transform))
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let session = UpscalingExportSession(
+            asset: AVAsset(url: source),
+            preferredOutputURL: source.renamed { "\($0) Upscaled" },
+            outputSize: CGSize(width: 320, height: 240)
+        )
+        defer { try? FileManager.default.removeItem(at: session.outputURL) }
+        try await session.export()
+
+        let track = try await AVAsset(url: session.outputURL).loadTracks(withMediaType: .video).first
+        let outputTransform = try #require(try await track?.load(.preferredTransform))
+        #expect(abs(outputTransform.a - transform.a) < 0.0001)
+        #expect(abs(outputTransform.b - transform.b) < 0.0001)
+        #expect(abs(outputTransform.c - transform.c) < 0.0001)
+        #expect(abs(outputTransform.d - transform.d) < 0.0001)
     }
 
     /// https://github.com/finnvoor/fx-upscale/commit/e6666afdb9a5ce1eda38437bec25b0743b740360
-    func testUpscaleMissingColorInfo() async throws {
-        // make sure it doesn't crash
-        throw XCTSkip("unimplemented")
+    @Test func upscaleMissingColorInfo() async throws {
+        // The generated source carries no color primaries/transfer/matrix tags.
+        let source = try TestMedia.makeVideo(.init(frameCount: 8))
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let session = UpscalingExportSession(
+            asset: AVAsset(url: source),
+            preferredOutputURL: source.renamed { "\($0) Upscaled" },
+            outputSize: CGSize(width: 320, height: 240)
+        )
+        defer { try? FileManager.default.removeItem(at: session.outputURL) }
+        try await session.export() // must not crash or throw
+        #expect(FileManager.default.fileExists(atPath: session.outputURL.path))
     }
 
     /// https://github.com/finnvoor/fx-upscale/commit/44463975e46ee7d418ad41017782c1e267205c82
-    func testTranscodeToProRes() async throws {
-        // >4k converted to pro res
-        throw XCTSkip("unimplemented")
+    @Test func transcodeToProRes() async throws {
+        let source = try TestMedia.makeVideo(.init(frameCount: 8))
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        // Prefer an .mp4 URL to prove ProRes forces a .mov container.
+        let preferred = source.renamed { "\($0) Upscaled" }
+            .deletingPathExtension()
+            .appendingPathExtension("mp4")
+        let session = UpscalingExportSession(
+            asset: AVAsset(url: source),
+            outputCodec: .proRes422,
+            preferredOutputURL: preferred,
+            outputSize: CGSize(width: 320, height: 240)
+        )
+        defer { try? FileManager.default.removeItem(at: session.outputURL) }
+
+        #expect(session.outputURL.pathExtension == "mov")
+        try await session.export()
+
+        let track = try await AVAsset(url: session.outputURL).loadTracks(withMediaType: .video).first
+        let format = try await track?.load(.formatDescriptions).first
+        #expect(format?.mediaSubType == .proRes422)
     }
 
     /// https://github.com/finnvoor/fx-upscale/issues/7
-    func testAudioFormatMaintained() async throws {
-        // keep audio format
-        throw XCTSkip("unimplemented")
+    @Test func audioFormatMaintained() async throws {
+        let source = try TestMedia.makeVideo(.init(frameCount: 12, includeAudio: true))
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let sourceAudio = try await AVAsset(url: source).loadTracks(withMediaType: .audio).first
+        let sourceFormat = try await sourceAudio?.load(.formatDescriptions).first
+        #expect(sourceFormat?.mediaSubType == .linearPCM)
+
+        let session = UpscalingExportSession(
+            asset: AVAsset(url: source),
+            preferredOutputURL: source.renamed { "\($0) Upscaled" },
+            outputSize: CGSize(width: 320, height: 240)
+        )
+        defer { try? FileManager.default.removeItem(at: session.outputURL) }
+        try await session.export()
+
+        let output = AVAsset(url: session.outputURL)
+        let outputAudio = try await output.loadTracks(withMediaType: .audio).first
+        let outputFormat = try await outputAudio?.load(.formatDescriptions).first
+        #expect(outputAudio != nil, "audio track should be preserved")
+        #expect(outputFormat?.mediaSubType == .linearPCM, "audio should be passed through unchanged")
+        // Video frames still all present alongside audio.
+        let sourceFrames = try await AVAsset(url: source).videoFrameCount()
+        let outputFrames = try await output.videoFrameCount()
+        #expect(outputFrames == sourceFrames)
     }
 
     /// https://github.com/finnvoor/fx-upscale/issues/6
-    func testMaintainMetadata() async throws {
-        // maintain metadata/captions
-        throw XCTSkip("unimplemented")
+    @Test func maintainMetadata() async throws {
+        let item = AVMutableMetadataItem()
+        item.identifier = .commonIdentifierTitle
+        item.value = "fx-upscale-title" as NSString
+        item.extendedLanguageTag = "und"
+
+        let source = try TestMedia.makeVideo(.init(frameCount: 6, metadata: [item]))
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let session = UpscalingExportSession(
+            asset: AVAsset(url: source),
+            preferredOutputURL: source.renamed { "\($0) Upscaled" },
+            outputSize: CGSize(width: 320, height: 240)
+        )
+        defer { try? FileManager.default.removeItem(at: session.outputURL) }
+        try await session.export()
+
+        let metadata = try await AVAsset(url: session.outputURL).load(.metadata)
+        let titles = AVMetadataItem.metadataItems(
+            from: metadata,
+            filteredByIdentifier: .commonIdentifierTitle
+        )
+        #expect(titles.first?.stringValue == "fx-upscale-title")
     }
 
     /// https://github.com/finnvoor/fx-upscale/issues/4
-    func testExportProgress() async throws {
-        // ensure progress works
-        throw XCTSkip("unimplemented")
+    @Test func exportProgress() async throws {
+        let source = try TestMedia.makeVideo(.init(frameCount: 60, fps: 30))
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let session = UpscalingExportSession(
+            asset: AVAsset(url: source),
+            preferredOutputURL: source.renamed { "\($0) Upscaled" },
+            outputSize: CGSize(width: 320, height: 240)
+        )
+        defer { try? FileManager.default.removeItem(at: session.outputURL) }
+
+        #expect(session.progress.fractionCompleted == 0)
+        try await session.export()
+        #expect(session.progress.fractionCompleted > 0, "progress should advance during export")
     }
 
-    func testFilter() async throws {
-        let inputImage = CIImage(
-            contentsOf: Bundle.module.url(forResource: "ladybird", withExtension: "jpg")!
-        )!
+    @Test func writesCreatorMetadata() async throws {
+        let source = try TestMedia.makeVideo(.init(frameCount: 4))
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let session = UpscalingExportSession(
+            asset: AVAsset(url: source),
+            preferredOutputURL: source.renamed { "\($0) Upscaled" },
+            outputSize: CGSize(width: 320, height: 240),
+            creator: "UnitTest"
+        )
+        defer { try? FileManager.default.removeItem(at: session.outputURL) }
+        try await session.export()
+
+        let values = try session.outputURL.resourceValues(forKeys: [.nameKey])
+        #expect(values.name != nil)
+        #expect(FileManager.default.fileExists(atPath: session.outputURL.path))
+    }
+
+    @Test func throwsWhenOutputExists() async throws {
+        let source = try TestMedia.makeVideo(.init(frameCount: 4))
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let outputURL = source.renamed { "\($0) Upscaled" }
+        try Data().write(to: outputURL)
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let session = UpscalingExportSession(
+            asset: AVAsset(url: source),
+            preferredOutputURL: outputURL,
+            outputSize: CGSize(width: 320, height: 240)
+        )
+
+        await #expect {
+            try await session.export()
+        } throws: { error in
+            guard case UpscalingExportSession.Error.outputURLAlreadyExists = error else { return false }
+            return true
+        }
+    }
+
+    // MARK: Filter
+
+    @Test func filter() throws {
+        let url = try #require(Bundle.module.url(forResource: "ladybird", withExtension: "jpg"))
+        let inputImage = try #require(CIImage(contentsOf: url))
         let outputSize = CGSize(
             width: inputImage.extent.width * 8,
             height: inputImage.extent.height * 8
@@ -57,8 +239,8 @@ final class UpscalingTests: XCTestCase {
         let filter = UpscalingFilter()
         filter.inputImage = inputImage
         filter.outputSize = outputSize
-        let outputImage = filter.outputImage!
+        let outputImage = try #require(filter.outputImage)
         // TODO: - diff images
-        XCTAssertEqual(outputImage.extent.size, outputSize)
+        #expect(outputImage.extent.size == outputSize)
     }
 }


### PR DESCRIPTION
Refactors `UpscalingExportSession` to remove duplicated export-pipeline code. No public API changes.

- Collapses the two near-identical `processVideoSamples`/`processSpatialVideoSamples` methods into one generic `processVideoSamples<Frame>` driven by `decode`/`submitUpscale`/`append` closures. Removes the `MediaTrack` enum, the `NSObject` adaptor + `as!` cast, and the task-group `switch`.
- Replaces the triplicated `requestMediaDataWhenReady` + continuation boilerplate with a single `AVAssetWriterInput.appendSamples(label:)` async helper.
- Adds `TestMedia` and real tests (previously all `XCTSkip` stubs).